### PR TITLE
[PA61] fixed user name displayed for creator of detailed thread view

### DIFF
--- a/lib/view/community/detailed_thread_view.dart
+++ b/lib/view/community/detailed_thread_view.dart
@@ -5,13 +5,12 @@ import 'package:aura/widgets/app_bar_back_button.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
-import 'package:aura/view/tabs/community/fab_createthread.dart';
 
 import 'package:like_button/like_button.dart';
 import 'package:provider/provider.dart';
 
 void main() {
-  String threadID = "1";
+  String threadID = "2";
   runApp(
     MultiProvider(providers: [
       ChangeNotifierProvider(create: (context) => Thread_Manager()),
@@ -179,7 +178,7 @@ class _DisplayFullThreadState extends State<DisplayFullThread> {
                 children: <Widget>[
                   const SizedBox(width: 16),
                   Text(
-                      userMgr.getUsernameByID(userMgr.active_user_id) ??
+                      userMgr.getUsernameByID(threadMgr.getThreadByID(widget.threadID)!.userID) ??
                           "UNKNOWN USER",
                       style: DefaultTextStyle.of(context).style.apply(
                           color: Colors.grey[700],


### PR DESCRIPTION
https://aura-cz2006.atlassian.net/browse/PA-61?atlOrigin=eyJpIjoiZmZjNWI3NTQ2NmYwNDQyNGIzODhiZTUxNmVhOGY2ZDgiLCJwIjoiaiJ9

detailed thread view now display name of poster, not name of current active user