### PR TITLE
Fix - Validation for Edit Thread

### DIFF
--- a/lib/view/community/edit_thread_view.dart
+++ b/lib/view/community/edit_thread_view.dart
@@ -113,6 +113,10 @@ class _EditThreadViewState extends State<EditThreadView> {
         child: const Text("Submit"),
         onPressed: () {
           setState(() {
+            //Validation for empty fields. CANNOT SUBMIT IF EMPTY
+            if (!_formKey.currentState!.validate()){
+              return;
+            }
             // print(
             //     "Text: ${titleController.text}, Content: ${contentController.text}"); // TODO REMOVE
             thread_manager.editThread(


### PR DESCRIPTION
Added checking of validation in setState -> User is now unable to submit in editThread without filling the fields.